### PR TITLE
Removed Typeform url

### DIFF
--- a/nyheter/index.html
+++ b/nyheter/index.html
@@ -271,7 +271,7 @@
 						Har du något eller några års erfarenhet från byggbranschen och vill ta nästa steg i karriären där du
 						får möjlighet att själv koordinera både större och mindre besiktningsprojekt inom bygg- och fastighetsbranschen?
 					</p>
-					<a class="common-Link" href="https://sebastian209.typeform.com/to/MTdpEL" data-mode="1" target="_blank">
+					<a class="common-Link" href="https://www.besiktningsman.se/karriar/" data-mode="1" target="_blank">
 						<p>Ansök här</p>
 					</a>
 				</span>


### PR DESCRIPTION
Old Typeform url removed. Placed a link to the /karriar/ page instead